### PR TITLE
Remove Cask --dev flag from README, because it is no more

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ In addition to all required dependencies above:
 Install all emacs dependencies:
 
 ``` sh
-cask install --dev
+cask install
 ```
 
 ## Test environment setup


### PR DESCRIPTION
Just `cask install` works fine for me using current master [1].

See [2] for the Cask commit that changed this.

[1] https://github.com/cask/cask/commit/532e3638c2e4a44ee17706d4b26ed1a5a3fb99c5

[2] https://github.com/cask/cask/commit/a8a2f72#diff-8feb0391f6652d58c375809a707e454fa7f494630e162827ee585a2085c7fa16L49